### PR TITLE
add rules for assigning default code reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+
+# The listed users will automatically be added as reviewers if they match a given pattern.
+# Last match takes precedence.
+# More info: https://help.github.com/en/articles/about-code-owners
+
+* @mruffalo
+hubmap/frontend/src @sushma-ananda


### PR DESCRIPTION
Since I'm usually just assigning you as the reviewer anyway, this makes it the default.