### PR TITLE
dev/docker-compose.yml: make Django app depend on Postgres container

### DIFF
--- a/docker/base/reactjs_app/Dockerfile
+++ b/docker/base/reactjs_app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.4.0
+FROM node:12.6.0
 
 COPY . /opt/hubmap-data-portal
 WORKDIR /opt/hubmap-data-portal/hubmap/frontend

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - 8000
     volumes:
       - ../..:/opt/hubmap-data-portal
+    depends_on:
+      - "postgres"
   react_app:
     image: "hubmap/data-portal-reactjs-dev:latest"
     ports:


### PR DESCRIPTION
When starting everything through `docker-compose up` with an empty database,
the Django application often fails to start correctly, hanging after
"Watching for file changes with StatReloader".

Fix this (as far as I can tell) by making the Django application explicitly
depend on the Postgres service.