### PR TITLE
Fix local Docker config example

### DIFF
--- a/docker/dev-common/docker-compose.yml
+++ b/docker/dev-common/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '3'
 
 services:
   postgres:

--- a/docker/dev-local-example/docker-compose.yml
+++ b/docker/dev-local-example/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "5432:5432"
   django:
-    build: django-app
+    build: django_app
     ports:
       - "8000:8000"
     expose:


### PR DESCRIPTION
There was a mismatch between the directory containing the Django app Dockerfile
and the directory name specified in docker-compose.yml.