### PR TITLE
Small QoL improvement: add hubmap/frontend/templates/index.html

### DIFF
--- a/hubmap/frontend/templates/index.html
+++ b/hubmap/frontend/templates/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<title>Nothing</title>
+</head>
+<body>
+<p>If you're running this application in development mode,
+	you probably want to view the <a href="http://localhost:3000/">ReactJS frontend</a>.</p>
+<p>(This index.html template is overwritten by the production build of the application.)</p>
+</body>
+</html>


### PR DESCRIPTION
It's a little nicer for a user to see "look at the ReactJS app" instead of a `TemplateDoesNotExist` error.