### PR TITLE
test_in_containers.sh

### DIFF
--- a/test_in_containers.sh
+++ b/test_in_containers.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o pipefail
+
+REACT_CONTAINER=$(docker ps --format '{{.Names}}' | grep react)
+echo "React container: $REACT_CONTAINER"
+docker exec -it $REACT_CONTAINER npx eslint .
+docker exec -it $REACT_CONTAINER npm test
+
+DJANGO_CONTAINER=$(docker ps --format '{{.Names}}' | grep django)
+echo "Django container: $DJANGO_CONTAINER"
+docker exec -it $DJANGO_CONTAINER flake8
+docker exec -it $DJANGO_CONTAINER ./manage.py test
+# TODO: Fails ->
+# django.db.utils.OperationalError: could not translate host name "postgres" to address: Name or service not known


### PR DESCRIPTION
Proposed alternative to #90.

Do we need to worry about potentially multiple matches? We could handle that, if needed, but it doesn't feel like a priority.

I do get one error that needs to be fixed: `django.db.utils.OperationalError: could not translate host name "postgres" to address: Name or service not known`

Some qualms about this: Most environments make a distinction between development and production builds (ie, `requirements-dev.txt` or `--save-dev`) but if we need to run tests on our containers we lose part of that distinction. Perhaps it doesn't matter? The only downside that comes to mind is that the images will be just a bit larger. If we did want to worry about it, one possibility would be to make base images, with only the production dependencies, and then use those base images to make develop images which would just add the dev dependencies. Probably not worth it?