### PR TITLE
Mccalluc/just add email cookie to cypress

### DIFF
--- a/hubmap/frontend/cypress/integration/hubmap_spec.js
+++ b/hubmap/frontend/cypress/integration/hubmap_spec.js
@@ -24,7 +24,9 @@ describe('HuBMAP', () => {
     // Header:
     cy.contains('Browse');
     cy.contains('Help');
-    cy.contains('Logged in');
+    cy.contains('Logged in').click();
+    cy.contains('Globus email: test@gmail.com');
+    cy.contains('Logout from Globus');
 
     // Charts:
     cy.contains('# of Cells per Tissue, by Center');

--- a/hubmap/frontend/cypress/integration/hubmap_spec.js
+++ b/hubmap/frontend/cypress/integration/hubmap_spec.js
@@ -1,12 +1,21 @@
 /* eslint no-undef: 0 */
 // TODO: Configure eslint to recognize "cy" as a global.
 describe('HuBMAP', () => {
-  before(() => {
+  beforeEach(() => {
     cy.server();
     const api = 'http://localhost:8000/api';
     cy.route(`${api}/?format=json`, 'fixture:base.json');
     cy.route(`${api}/colors/?format=json`, 'fixture:colors.json');
     cy.route(`${api}/genes/?format=json`, 'fixture:genes.json');
+    // Mocking the OAuth response and iframe interaction is hard,
+    // but the UI really just depends on this cookie:
+    cy.setCookie('email', 'test@gmail.com')
+  });
+
+  it('Handles un-logged in', () => {
+    cy.clearCookie('email', 'test@gmail.com');
+    cy.visit('/');
+    cy.contains('Login');
   });
 
   it('Has a homepage', () => {
@@ -15,7 +24,7 @@ describe('HuBMAP', () => {
     // Header:
     cy.contains('Browse');
     cy.contains('Help');
-    cy.contains('Login');
+    cy.contains('Logged in');
 
     // Charts:
     cy.contains('# of Cells per Tissue, by Center');


### PR DESCRIPTION
Replaces PR #103: We learned from that trying to mock the login process in detail is not feasible, but if we just want to test the UI, that only depends on the presence or absence of a cookie, and this will be sufficient.