### PR TITLE
Move all eslint-disables from .eslintrc.yml to per-file

### DIFF
--- a/hubmap/frontend/.eslintrc.yml
+++ b/hubmap/frontend/.eslintrc.yml
@@ -15,40 +15,7 @@ parserOptions:
 plugins:
   - react
 rules:
-  camelcase: 0 # TODO
-  class-methods-use-this: 0 # TODO
-  func-names: 0 # TODO
-  global-require: 0 # TODO
-  import/named: 0 # TODO
-  import/no-cycle: 0 # TODO
-  import/no-extraneous-dependencies: 0 # TODO
-  import/no-mutable-exports: 0 # TODO
-  import/no-unresolved: 0 # TODO
-  import/prefer-default-export: 0 # TODO
-  max-len: 0 # TODO
-  no-console: 0 # TODO
-  no-mixed-spaces-and-tabs: 0 # TODO
-  no-param-reassign: 0 # TODO
-  no-plusplus: 0 # TODO
-  no-return-assign: 0 # TODO
-  no-shadow: 0 # TODO
-  no-tabs: 0 # TODO
-  no-undef: 0 # TODO
-  no-underscore-dangle: 0 # TODO
-  no-unused-expressions: 0 # TODO
-  no-unused-vars: 0 # TODO
-  no-use-before-define: 0 # TODO
-  no-useless-concat: 0 # TODO
-  prefer-const: 0 # TODO
-  prefer-destructuring: 0 # TODO
-  react/destructuring-assignment: 0 # TODO
-  react/forbid-prop-types: 0 # TODO
-  react/jsx-filename-extension: 0 # TODO
-  react/jsx-props-no-spreading: 0 # TODO
-  react/no-access-state-in-setstate: 0 # TODO
-  react/no-unused-state: 0 # TODO
-  react/prefer-stateless-function: 0 # TODO
-  react/prop-types: 0 # TODO
-  react/require-default-props: 0 # TODO
-  react/sort-comp: 0 # TODO
-  react/state-in-constructor: 0 # TODO
+  no-console: [2, { "allow": ["warn", "error"]}]  # Lower levels used for debugging should not be checked in.
+  react/jsx-filename-extension: [0]  # JSX is ubiquitous; We don't need to make it explicit.
+  react/sort-comp: [0]  # Non-alphabetical groupings can make more sense.
+  react/jsx-one-expression-per-line: [0]  # Makes punctuation after tab awkward.

--- a/hubmap/frontend/cypress/plugins/index.js
+++ b/hubmap/frontend/cypress/plugins/index.js
@@ -11,7 +11,7 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
-module.exports = (on, config) => {
+module.exports = (on, config) => { // eslint-disable-line no-unused-vars
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
 };

--- a/hubmap/frontend/src/App.js
+++ b/hubmap/frontend/src/App.js
@@ -1,3 +1,9 @@
+// TODO!
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable max-len */
+/* eslint-disable import/no-cycle */
+/* eslint-disable react/prop-types */
+
 import './App.scss';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';

--- a/hubmap/frontend/src/GitVersion.js
+++ b/hubmap/frontend/src/GitVersion.js
@@ -4,7 +4,7 @@
 
 let GitVersion;
 try {
-  GitVersion = require('./git-version.json').version;
+  GitVersion = require('./git-version.json').version; // eslint-disable-line import/no-unresolved
 } catch (e) {
   GitVersion = () => '[unknown version]';
 }

--- a/hubmap/frontend/src/GitVersion.js
+++ b/hubmap/frontend/src/GitVersion.js
@@ -1,3 +1,7 @@
+// TODO!
+/* eslint-disable global-require */
+/* eslint-disable import/no-mutable-exports */
+
 let GitVersion;
 try {
   GitVersion = require('./git-version.json').version;

--- a/hubmap/frontend/src/commons/apiAdapter.js
+++ b/hubmap/frontend/src/commons/apiAdapter.js
@@ -1,3 +1,7 @@
+// TODO!
+/* eslint-disable import/no-mutable-exports */
+/* eslint-disable prefer-const */
+
 let API_URL;
 
 API_URL = process.env.REACT_APP_STAGE === 'dev'

--- a/hubmap/frontend/src/commons/utils.js
+++ b/hubmap/frontend/src/commons/utils.js
@@ -1,3 +1,7 @@
+// TODO!
+/* eslint-disable no-plusplus */
+/* eslint-disable no-use-before-define */
+
 export { addAnimationToStyle };
 let dynamicStyles = null;
 export default function addAnimationToStyle(animationName, animationSteps) {

--- a/hubmap/frontend/src/components/Experiments.js
+++ b/hubmap/frontend/src/components/Experiments.js
@@ -1,3 +1,12 @@
+// TODO!
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable react/forbid-prop-types */
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable react/no-unused-state */
+/* eslint-disable no-unused-vars */
+/* eslint-disable react/require-default-props */
+/* eslint-disable react/state-in-constructor */
+
 import React from 'react';
 import grey from '@material-ui/core/colors/grey';
 import PropTypes from 'prop-types';

--- a/hubmap/frontend/src/components/Footer.js
+++ b/hubmap/frontend/src/components/Footer.js
@@ -1,3 +1,6 @@
+// TODO!
+/* eslint-disable no-unused-vars */
+
 import React from 'react';
 import '../App.scss';
 import { makeStyles } from '@material-ui/core/styles';

--- a/hubmap/frontend/src/components/NavBar.js
+++ b/hubmap/frontend/src/components/NavBar.js
@@ -1,3 +1,6 @@
+// TODO!
+/* eslint-disable no-unused-vars */
+
 import React from 'react';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';

--- a/hubmap/frontend/src/components/RootContainer.js
+++ b/hubmap/frontend/src/components/RootContainer.js
@@ -1,3 +1,6 @@
+// TODO!
+/* eslint-disable import/no-cycle */
+
 import React from 'react';
 import Container from '@material-ui/core/Container';
 import { Route, BrowserRouter } from 'react-router-dom';

--- a/hubmap/frontend/src/components/home/BarChart.js
+++ b/hubmap/frontend/src/components/home/BarChart.js
@@ -1,3 +1,8 @@
+// TODO!
+/* eslint-disable func-names */
+/* eslint-disable no-return-assign */
+/* eslint-disable no-unused-vars */
+
 import React from 'react';
 import * as d3 from 'd3';
 

--- a/hubmap/frontend/src/components/home/CellCountByTissueChart.js
+++ b/hubmap/frontend/src/components/home/CellCountByTissueChart.js
@@ -1,3 +1,11 @@
+// TODO!
+/* eslint-disable camelcase */
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable max-len */
+/* eslint-disable import/no-cycle */
+/* eslint-disable no-return-assign */
+/* eslint-disable react/prop-types */
+
 import React, { PureComponent } from 'react';
 import { Chart } from 'react-google-charts';
 import { connect } from 'react-redux';

--- a/hubmap/frontend/src/components/home/CellCountChart.js
+++ b/hubmap/frontend/src/components/home/CellCountChart.js
@@ -1,3 +1,7 @@
+// TODO!
+/* eslint-disable no-return-assign */
+/* eslint-disable import/no-unresolved */
+
 import React from 'react';
 import * as d3 from 'd3';
 import './App.scss';

--- a/hubmap/frontend/src/components/home/D3chart.js
+++ b/hubmap/frontend/src/components/home/D3chart.js
@@ -1,3 +1,15 @@
+// TODO!
+/* eslint-disable camelcase */
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable func-names */
+/* eslint-disable max-len */
+/* eslint-disable import/no-cycle */
+/* eslint-disable no-return-assign */
+/* eslint-disable no-shadow */
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-use-before-define */
+/* eslint-disable react/prop-types */
+
 import React from 'react';
 import * as d3 from 'd3';
 import { CircularProgress, Typography } from '@material-ui/core';

--- a/hubmap/frontend/src/components/home/ExperimentD3BarChart.js
+++ b/hubmap/frontend/src/components/home/ExperimentD3BarChart.js
@@ -1,3 +1,8 @@
+// TODO!
+/* eslint-disable class-methods-use-this */
+/* eslint-disable import/no-unresolved */
+/* eslint-disable no-unused-vars */
+
 import * as d3 from 'd3';
 import { Component } from 'react';
 import { Element } from 'react-faux-dom';

--- a/hubmap/frontend/src/components/home/Experiments.js
+++ b/hubmap/frontend/src/components/home/Experiments.js
@@ -1,3 +1,13 @@
+// TODO!
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable react/forbid-prop-types */
+/* eslint-disable no-undef */
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable react/no-unused-state */
+/* eslint-disable no-unused-vars */
+/* eslint-disable react/require-default-props */
+/* eslint-disable react/state-in-constructor */
+
 import React from 'react';
 import grey from '@material-ui/core/colors/grey';
 import PropTypes from 'prop-types';

--- a/hubmap/frontend/src/components/home/ExperimentsTable.js
+++ b/hubmap/frontend/src/components/home/ExperimentsTable.js
@@ -1,3 +1,12 @@
+// TODO!
+/* eslint-disable camelcase */
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable max-len */
+/* eslint-disable import/named */
+/* eslint-disable no-return-assign */
+/* eslint-disable import/no-unresolved */
+/* eslint-disable react/prop-types */
+
 import React from 'react';
 import { connect } from 'react-redux';
 import { get_experiments, in_progress } from '../controllers/actions';

--- a/hubmap/frontend/src/components/home/HuBMAPContainer.js
+++ b/hubmap/frontend/src/components/home/HuBMAPContainer.js
@@ -1,3 +1,6 @@
+// TODO!
+/* eslint-disable react/forbid-prop-types */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';

--- a/hubmap/frontend/src/components/home/HumanSvgComponent.js
+++ b/hubmap/frontend/src/components/home/HumanSvgComponent.js
@@ -1,3 +1,17 @@
+// TODO!
+/* eslint-disable camelcase */
+/* eslint-disable import/no-cycle */
+/* eslint-disable max-len */
+/* eslint-disable no-console */
+/* eslint-disable no-mixed-spaces-and-tabs */
+/* eslint-disable no-param-reassign */
+/* eslint-disable no-plusplus */
+/* eslint-disable no-tabs */
+/* eslint-disable no-unused-vars */
+/* eslint-disable prefer-destructuring */
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable react/prop-types */
+
 import React from 'react';
 import { connect } from 'react-redux';
 import { ReactComponent as ReactComp } from '../../images/Human_body_silhouette_minimal.svg';

--- a/hubmap/frontend/src/components/home/HumanSvgWithSearchComponent.js
+++ b/hubmap/frontend/src/components/home/HumanSvgWithSearchComponent.js
@@ -1,3 +1,7 @@
+// TODO!
+/* eslint-disable import/no-cycle */
+/* eslint-disable no-unused-vars */
+
 import React from 'react';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import HumanAnatomyCard from './HumanSvgComponent';

--- a/hubmap/frontend/src/components/home/ImageCountByTissueChart.js
+++ b/hubmap/frontend/src/components/home/ImageCountByTissueChart.js
@@ -1,3 +1,11 @@
+// TODO!
+/* eslint-disable camelcase */
+/* eslint-disable import/no-cycle */
+/* eslint-disable max-len */
+/* eslint-disable no-return-assign */
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable react/prop-types */
+
 import React, { PureComponent } from 'react';
 import { Chart } from 'react-google-charts';
 import { connect } from 'react-redux';

--- a/hubmap/frontend/src/components/home/MUITable.js
+++ b/hubmap/frontend/src/components/home/MUITable.js
@@ -1,3 +1,17 @@
+// TODO!
+/* eslint-disable camelcase */
+/* eslint-disable class-methods-use-this */
+/* eslint-disable import/no-cycle */
+/* eslint-disable max-len */
+/* eslint-disable no-mixed-spaces-and-tabs */
+/* eslint-disable no-return-assign */
+/* eslint-disable no-tabs */
+/* eslint-disable no-unused-expressions */
+/* eslint-disable no-unused-vars */
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable react/no-unused-state */
+/* eslint-disable react/prop-types */
+
 import React from 'react';
 import MUIDataTable from 'mui-datatables';
 import grey from '@material-ui/core/colors/grey';

--- a/hubmap/frontend/src/components/home/Search.js
+++ b/hubmap/frontend/src/components/home/Search.js
@@ -1,3 +1,16 @@
+// TODO!
+/* eslint-disable camelcase */
+/* eslint-disable import/no-cycle */
+/* eslint-disable max-len */
+/* eslint-disable no-console */
+/* eslint-disable no-param-reassign */
+/* eslint-disable no-return-assign */
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-useless-concat */
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable react/no-access-state-in-setstate */
+/* eslint-disable react/prop-types */
+
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import InputBase from '@material-ui/core/InputBase';

--- a/hubmap/frontend/src/icons/ForwardIcon.js
+++ b/hubmap/frontend/src/icons/ForwardIcon.js
@@ -1,3 +1,7 @@
+// TODO!
+/* eslint-disable react/forbid-prop-types */
+/* eslint-disable react/jsx-props-no-spreading */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';

--- a/hubmap/frontend/src/icons/MicroscopeIcon.js
+++ b/hubmap/frontend/src/icons/MicroscopeIcon.js
@@ -1,3 +1,7 @@
+// TODO!
+/* eslint-disable react/forbid-prop-types */
+/* eslint-disable react/jsx-props-no-spreading */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';

--- a/hubmap/frontend/src/icons/SettingsIcon.js
+++ b/hubmap/frontend/src/icons/SettingsIcon.js
@@ -1,3 +1,7 @@
+// TODO!
+/* eslint-disable react/forbid-prop-types */
+/* eslint-disable react/jsx-props-no-spreading */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';

--- a/hubmap/frontend/src/index.js
+++ b/hubmap/frontend/src/index.js
@@ -1,3 +1,7 @@
+// TODO!
+/* eslint-disable import/no-cycle */
+/* eslint-disable import/prefer-default-export */
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';

--- a/hubmap/frontend/src/middleware/actions.js
+++ b/hubmap/frontend/src/middleware/actions.js
@@ -1,3 +1,8 @@
+// TODO!
+/* eslint-disable camelcase */
+/* eslint-disable max-len */
+/* eslint-disable no-console */
+/* eslint-disable no-unused-vars */
 
 import axios from 'axios';
 import * as Constants from '../commons/constants';

--- a/hubmap/frontend/src/pages/DataAnalysis.js
+++ b/hubmap/frontend/src/pages/DataAnalysis.js
@@ -1,3 +1,7 @@
+// TODO!
+/* eslint-disable import/no-cycle */
+/* eslint-disable react/prefer-stateless-function */
+
 import React from 'react';
 import CellCountByTissueChart from '../components/home/CellCountByTissueChart';
 import ImageCountByTissuesChart from '../components/home/ImageCountByTissueChart';

--- a/hubmap/frontend/src/pages/Experiments.js
+++ b/hubmap/frontend/src/pages/Experiments.js
@@ -1,3 +1,6 @@
+// TODO!
+/* eslint-disable react/prefer-stateless-function */
+
 import React from 'react';
 
 class ExperimentsComponent extends React.Component {

--- a/hubmap/frontend/src/pages/HomePage.js
+++ b/hubmap/frontend/src/pages/HomePage.js
@@ -1,3 +1,7 @@
+// TODO!
+/* eslint-disable import/no-cycle */
+/* eslint-disable no-unused-vars */
+
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';

--- a/hubmap/frontend/src/pages/Pipelines.js
+++ b/hubmap/frontend/src/pages/Pipelines.js
@@ -1,3 +1,6 @@
+// TODO!
+/* eslint-disable react/prefer-stateless-function */
+
 import React from 'react';
 
 class PipelinesComponent extends React.Component {

--- a/hubmap/frontend/src/pages/UserFAQs.js
+++ b/hubmap/frontend/src/pages/UserFAQs.js
@@ -1,3 +1,6 @@
+// TODO!
+/* eslint-disable react/prefer-stateless-function */
+
 import React from 'react';
 
 class UserFAQsComponent extends React.Component {

--- a/hubmap/frontend/src/trivial.test.js
+++ b/hubmap/frontend/src/trivial.test.js
@@ -1,3 +1,7 @@
+// TODO!
+/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable no-undef */
+
 import expect from 'expect';
 
 it('can run a trivial test', () => {


### PR DESCRIPTION
Leave a handful as globals which I have found to be unhelpful in the past; May add to that list.

Going forward, expect it will be easiest to fix problems one file at a time to avoid merge conflicts, but if there are easy global solutions, we can still do that.

If you don't agree with the disables which have been kept in .eslintrc.yml, or you think others should be added to the list, feel free to respond here, or let me know as we move forward.

