### PR TITLE
Docker tweaks (incl. adding MongoDB)

### DIFF
--- a/docker/base/reactjs_app/Dockerfile
+++ b/docker/base/reactjs_app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.8.0
+FROM node:12.9
 
 COPY . /opt/hubmap-data-portal
 WORKDIR /opt/hubmap-data-portal/hubmap/frontend

--- a/docker/dev-common/docker-compose.yml
+++ b/docker/dev-common/docker-compose.yml
@@ -32,9 +32,6 @@ services:
     ports:
       - "7474:7474"
       - "7687:7687"
-    expose:
-      - 7474
-      - 7687
   elasticsearch:
     image: elasticsearch:7.2.0
     environment:
@@ -42,15 +39,10 @@ services:
     ports:
       - "9200:9200"
       - "9300:9300"
-    expose:
-      - 9200
-      - 9300
   rabbitmq:
     image: rabbitmq:3.5
     ports:
       - "5672:5672"
-    expose:
-      - 5672
   mongodb:
     image: mongo:4.2
     ports:

--- a/docker/dev-common/docker-compose.yml
+++ b/docker/dev-common/docker-compose.yml
@@ -51,6 +51,10 @@ services:
       - "5672:5672"
     expose:
       - 5672
+  mongodb:
+    image: mongo:4.2
+    ports:
+      - "27017:27017"
 #  nginx:
 #    build: nginx
 #    ports:

--- a/docker/dev-local-example/docker-compose.yml
+++ b/docker/dev-local-example/docker-compose.yml
@@ -32,9 +32,6 @@ services:
     ports:
       - "7474:7474"
       - "7687:7687"
-    expose:
-      - 7474
-      - 7687
   elasticsearch:
     image: elasticsearch:7.2.0
     environment:
@@ -42,15 +39,14 @@ services:
     ports:
       - "9200:9200"
       - "9300:9300"
-    expose:
-      - 9200
-      - 9300
   rabbitmq:
     image: rabbitmq:3.5
     ports:
       - "5672:5672"
-    expose:
-      - 5672
+  mongodb:
+    image: mongo:4.2
+    ports:
+      - "27017:27017"
 #  nginx:
 #    build: nginx
 #    ports:


### PR DESCRIPTION
1. Bump Node container version to 12.9
1. Add MongoDB container to 'common' development Docker config
1. Don't expose service ports to the host system, only to the other containers -- there shouldn't be much reason to access these services in the host system. This can be overridden with a local Docker config, if desired.