### PR TITLE
Update eslint-utils package to 1.4.2

### DIFF
--- a/hubmap/frontend/package-lock.json
+++ b/hubmap/frontend/package-lock.json
@@ -5923,9 +5923,9 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
-      "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
       "requires": {
         "eslint-visitor-keys": "^1.0.0"
       }


### PR DESCRIPTION
This was suggested by npm:

```
react_app_1      | audited 904392 packages in 14.398s
react_app_1      | found 2 critical severity vulnerabilities
react_app_1      |   run `npm audit fix` to fix them, or `npm audit` for details
```