### PR TITLE
More Docker updates

### DIFF
--- a/docker/dev-common/docker-compose.yml
+++ b/docker/dev-common/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - "7474:7474"
       - "7687:7687"
   elasticsearch:
-    image: elasticsearch:7.2.0
+    image: elasticsearch:7.3.1
     environment:
       - discovery.type=single-node
     ports:

--- a/docker/dev-common/docker-compose.yml
+++ b/docker/dev-common/docker-compose.yml
@@ -39,10 +39,6 @@ services:
     ports:
       - "9200:9200"
       - "9300:9300"
-  rabbitmq:
-    image: rabbitmq:3.5
-    ports:
-      - "5672:5672"
   mongodb:
     image: mongo:4.2
     ports:

--- a/docker/dev-local-example/docker-compose.yml
+++ b/docker/dev-local-example/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - "7474:7474"
       - "7687:7687"
   elasticsearch:
-    image: elasticsearch:7.2.0
+    image: elasticsearch:7.3.1
     environment:
       - discovery.type=single-node
     ports:

--- a/docker/dev-local-example/docker-compose.yml
+++ b/docker/dev-local-example/docker-compose.yml
@@ -39,10 +39,6 @@ services:
     ports:
       - "9200:9200"
       - "9300:9300"
-  rabbitmq:
-    image: rabbitmq:3.5
-    ports:
-      - "5672:5672"
   mongodb:
     image: mongo:4.2
     ports:


### PR DESCRIPTION
Bump Elasticsearch version to 7.3.1, and remove RabbitMQ for now.