### PR TITLE
Test static build of app via Cypress

### DIFF
--- a/hubmap/frontend/.eslintignore
+++ b/hubmap/frontend/.eslintignore
@@ -1,1 +1,2 @@
 cypress/integration-examples
+build/

--- a/hubmap/frontend/cypress/integration/hubmap_spec.js
+++ b/hubmap/frontend/cypress/integration/hubmap_spec.js
@@ -57,7 +57,8 @@ describe('HuBMAP', () => {
     cy.visit('/');
 
     cy.contains('Browse').click();
-    cy.contains('Data Analysis').click();
+    // https://github.com/rakannimer/react-google-charts/blob/master/cypress/integration/charts.spec.js
+    cy.contains('Data Analysis', { timeout: 100000 }).click();
     cy.location('pathname').should('eq', '/dataanalysis');
     cy.contains('Search by Tissue'); // TODO: more tests
 

--- a/test.sh
+++ b/test.sh
@@ -33,6 +33,7 @@ end eslint
 
 start cypress
 pushd hubmap/frontend
+echo '{"version": "unknown"}' > src/git-version.json
 REACT_APP_STAGE=dev npm run build
 pushd build
 python3 -m http.server --bind localhost 3000 &

--- a/test.sh
+++ b/test.sh
@@ -33,8 +33,11 @@ end eslint
 
 start cypress
 pushd hubmap/frontend
-npm start &
+REACT_APP_STAGE=dev npm run build
+pushd build
+python3 -m http.server --bind localhost 3000 &
 SERVER_PID=$!
+popd
 $(npm bin)/wait-on http://localhost:3000
 $(npm bin)/cypress run
 kill $SERVER_PID


### PR DESCRIPTION
We should have some test coverage for "can we create a static build of the application, which can be served in production?"

Run Cypress against the output of `npm run build` (hosted via the Python `http.server` module).