### PR TITLE
Bump Django version to 2.2.6

### DIFF
--- a/hubmap/requirements.txt
+++ b/hubmap/requirements.txt
@@ -2,7 +2,7 @@ bokeh==1.3.2
 celery==4.3.0
 coreapi==2.3.3
 coreapi-cli==1.0.9
-Django==2.2.5
+Django==2.2.6
 django-cors-headers==3.0.2
 django-filter==2.2.0
 django-oauth-toolkit>=1.0.0


### PR DESCRIPTION
Release notes: https://docs.djangoproject.com/en/2.2/releases/2.2.6/