### PR TITLE
Mccalluc/mock api container

### DIFF
--- a/docker/dev-common/api/Dockerfile
+++ b/docker/dev-common/api/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:rc-alpine3.10
+
+EXPOSE 9999
+WORKDIR /home
+COPY . .
+
+CMD ["python", "-m", "http.server", "9999"]

--- a/docker/dev-common/api/hello.txt
+++ b/docker/dev-common/api/hello.txt
@@ -1,1 +1,0 @@
-Hello world!

--- a/docker/dev-common/api/hello.txt
+++ b/docker/dev-common/api/hello.txt
@@ -1,0 +1,1 @@
+Hello world!

--- a/docker/dev-common/api/v0/entities/11866f9586fdac34c95ac8a2737a83dd
+++ b/docker/dev-common/api/v0/entities/11866f9586fdac34c95ac8a2737a83dd
@@ -1,0 +1,13 @@
+{
+  "provenance_create_timestamp": 1567520904428,
+  "provenance_user_email": "shirey@pitt.edu",
+  "provenance_group_name": "hubmap-testing",
+  "user_group_uuid": "5bd084c8-edc2-11e8-802f-0e368f3075e8",
+  "description": "Test Donor 1",
+  "label": "Bill Test 1",
+  "uuid": "11866f9586fdac34c95ac8a2737a83dd",
+  "provenance_user_displayname": "William Shirey",
+  "provenance_group_uuid": "5bd084c8-edc2-11e8-802f-0e368f3075e8",
+  "provenance_user_sub": "e19adbbb-73c3-43a7-b05e-0eead04f5ff8",
+  "provenance_modified_timestamp": 1567520904428
+}

--- a/docker/dev-common/api/v0/entities/donors/created-by/shirey@pitt.edu
+++ b/docker/dev-common/api/v0/entities/donors/created-by/shirey@pitt.edu
@@ -1,0 +1,11 @@
+{
+  "uuids" : [
+    "11866f9586fdac34c95ac8a2737a83dd",
+    "b2b59b227e0dfd7ddd4799f909bc3f01",
+    "c3323cecca52e99113a56946a2bcdd5f",
+    "44e00b44dda813cd39da6934c8954d71",
+    "c0bfcf32a6da83c37a5ed7b2eeabdefe",
+    "c83b24f93af72ffcee0dd94ad1d61d7a",
+    "a41210275f08ec8b8b973a4f10a73e5f"
+  ]
+}

--- a/docker/dev-common/api/v0/entities/donors/index.html
+++ b/docker/dev-common/api/v0/entities/donors/index.html
@@ -1,0 +1,11 @@
+{
+  "uuids" : [
+    "11866f9586fdac34c95ac8a2737a83dd",
+    "b2b59b227e0dfd7ddd4799f909bc3f01",
+    "c3323cecca52e99113a56946a2bcdd5f",
+    "44e00b44dda813cd39da6934c8954d71",
+    "c0bfcf32a6da83c37a5ed7b2eeabdefe",
+    "c83b24f93af72ffcee0dd94ad1d61d7a",
+    "a41210275f08ec8b8b973a4f10a73e5f"
+  ]
+}

--- a/docker/dev-common/api/v0/entities/index.html
+++ b/docker/dev-common/api/v0/entities/index.html
@@ -1,0 +1,1 @@
+{"entity_types" : ["Sample", "Donor", "Dataset"]}

--- a/docker/dev-common/api/v0/entities/samples/organ-type/liver
+++ b/docker/dev-common/api/v0/entities/samples/organ-type/liver
@@ -1,0 +1,6 @@
+{
+  "uuids" : [
+    "ae6bf50908a4a2089d2eacd8e464fe86",
+    "37ef1d1d79c1e2a50ea6d18cdbb3762c"
+  ]
+}

--- a/docker/dev-common/api/v0/entities/samples/sample-type/organ
+++ b/docker/dev-common/api/v0/entities/samples/sample-type/organ
@@ -1,0 +1,8 @@
+{
+  "uuids" : [
+    "ae6bf50908a4a2089d2eacd8e464fe86",
+    "45ad98de3c9b5983a274d801969ae464",
+    "37ef1d1d79c1e2a50ea6d18cdbb3762c",
+    "f7c3c6a3ded8876226a673249b4a8423"
+  ]
+}

--- a/docker/dev-common/docker-compose.yml
+++ b/docker/dev-common/docker-compose.yml
@@ -1,6 +1,11 @@
 version: '3'
 
 services:
+  api:
+    build:
+      context: ./api
+    ports:
+      - "9999:9999"
   postgres:
     image: postgres:11
     environment:


### PR DESCRIPTION
@cborromeo has said he would forward a conversation including me and Matt: We would like to know where API development will happen, and what url we can hit.
- Matt would strongly prefer that it be done in the existing Django, as a separate Django app, to prevent a proliferation of services. (I'll make another PR to demonstrate that approach.)
- I have a slight preference for establishing a new container to do this, with sample data for now (this PR), to simplify the Django container's dependencies, and to have a clearer separation of concerns. (I am adding more slashes to the path, rather than doing queries, so that it can be based on the file-system for now.)
- It would also be possible to do the work in an entirely separate repo, and push an image to Dockerhub, where it could be referenced from the docker compose, but I don't think anyone is advocating for that.

Chuck Borromeo believes that this is your decision to make: If you can't make an immediate call, please give us an estimate for when the decision will be made.

Thanks!

(Towards #138)